### PR TITLE
Add licence note to all files

### DIFF
--- a/carteiro.asd
+++ b/carteiro.asd
@@ -1,10 +1,21 @@
 #|
   This file is a part of carteiro project.
   Copyright (c) 2019 Edgard Bikelis (bikelis@gmail.com)
-|#
 
-#|
   Author: Edgard Bikelis (bikelis@gmail.com)
+
+  Carteiro is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or (at
+  your option) any later version.
+
+  Carteiro is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Carteiro.  If not, see <https://www.gnu.org/licenses/>.
 |#
 
 (defsystem "carteiro"

--- a/carteiro.lisp
+++ b/carteiro.lisp
@@ -1,3 +1,23 @@
+#|
+  This file is a part of carteiro project.
+  Copyright (c) 2019 Edgard Bikelis (bikelis@gmail.com)
+
+  Author: Edgard Bikelis (bikelis@gmail.com)
+
+  Carteiro is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or (at
+  your option) any later version.
+
+  Carteiro is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Carteiro.  If not, see <https://www.gnu.org/licenses/>.
+|#
+
 (defpackage carteiro
   (:use :cl)
   (:export rastreio))


### PR DESCRIPTION
This commit adds the usual short license note to the .lisp and the .asd files